### PR TITLE
tmuxでディレクトリ移動時にウィンドウ名を自動更新する記事とプロジェクト改善

### DIFF
--- a/.claude/hooks/textlint.sh
+++ b/.claude/hooks/textlint.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Extract file path from hook input
+FILE_PATH=$(echo "$HOOK_INPUT" | jq -r '.file_path')
+
+# Only run textlint on markdown files in articles/ or books/
+if [[ "$FILE_PATH" == articles/*.md ]] || [[ "$FILE_PATH" == books/*.md ]]; then
+  echo "Running textlint on $FILE_PATH..."
+  docker compose run --rm npx textlint "$FILE_PATH"
+
+  if [ $? -ne 0 ]; then
+    echo "❌ textlint failed. Please fix the errors above."
+    exit 1
+  fi
+
+  echo "✅ textlint passed"
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "pathMatcher": "**/*.md",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/textlint.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,16 @@
+{
+  "mcpServers": {
+    "fetch": {
+      "command": "uvx",
+      "args": ["mcp-server-fetch"]
+    },
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "./articles", "./books"]
+    },
+    "git": {
+      "command": "uvx",
+      "args": ["mcp-server-git", "--repository", "."]
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,67 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a Zenn content repository for managing technical articles and books written in Japanese. Zenn is a Japanese platform for publishing technical content. All content is written in Markdown and managed via the Zenn CLI.
+
+## Development Environment
+
+All commands run inside a Docker container with Node.js LTS Alpine. The container includes:
+- zenn-cli (Zenn's official CLI)
+- textlint with Japanese technical writing presets
+
+## Common Commands
+
+All commands are executed via Makefile targets:
+
+```bash
+# Build Docker image
+make build
+
+# Initialize Zenn (first time setup)
+make init
+
+# Preview articles locally at http://localhost:8000
+make preview
+
+# Create a new article with a specific slug
+make article slug=your-article-slug
+
+# Create a new book with a specific slug
+make book slug=your-book-slug
+
+# Lint all articles and books
+make textlint
+```
+
+## Content Structure
+
+- **articles/**: Individual technical articles in Markdown format
+  - Each article has frontmatter with: title, emoji, type (tech/idea), topics, published status
+  - Articles use Zenn's Markdown dialect with special syntax like `:::message` and `:::details`
+
+- **books/**: Book content (currently empty but structure exists)
+
+## Writing Guidelines (from .textlintrc)
+
+When editing articles:
+- Maximum sentence length: 150 characters (Japanese)
+- Exclamation marks (！、？) are allowed
+- Weak phrases like 「かも」「思います」are allowed
+- Successive words (スラング) like 「あるある」「つよつよ」are allowed
+- Zenn's special Markdown blocks (`:::message`, `:::details`) are used and should be preserved
+- Must maintain consistent です/ます form (no mixing with だ/である form)
+- Tech terminology must be spelled correctly per textlint-rule-spellcheck-tech-word
+
+## CI/CD
+
+GitHub Actions runs textlint on all pull requests via `.github/workflows/test.yml` which executes `make build && make textlint`.
+
+## Important Notes
+
+- All content is in Japanese
+- Article filenames can be either a slug or a hash (e.g., `050e408742dc0522f752.md` or `terraform-nested-for-each-loop.md`)
+- Zenn platform documentation: https://zenn.dev/zenn/articles/zenn-cli-guide
+- Zenn Markdown guide: https://zenn.dev/zenn/articles/markdown-guide

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@ help: ## Print this help
 	@echo 'Targets:'
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
-build: ## exec docker-compose build
+build: ## exec docker compose build
 	@docker compose build
 
-init: build ## exec docker-compose build & npx zenn init
+init: build ## exec docker compose build & npx zenn init
 	@docker compose run --rm npx zenn init
 
 preview: ## exec npx zenn preview

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Likes](https://badgen.org/img/zenn/Tocyuki/likes?style=plastic)](https://zenn.dev/Tocyuki)
+[![Articles](https://badgen.org/img/zenn/Tocyuki/articles?style=plastic)](https://zenn.dev/Tocyuki)
+
 # Zenn Contents
 
 * [📘 How to use](https://zenn.dev/zenn/articles/zenn-cli-guide)

--- a/articles/tmux-auto-rename-window-on-directory-change.md
+++ b/articles/tmux-auto-rename-window-on-directory-change.md
@@ -1,0 +1,95 @@
+---
+title: "tmuxでディレクトリ移動時にウィンドウ名を自動更新する方法"
+emoji: "🖥️"
+type: "tech" # tech: 技術記事 / idea: アイデア
+topics: ["tmux", "zsh", "terminal"]
+published: true
+---
+
+## 概要
+
+tmuxで複数のプロジェクトを開いている際、どのウィンドウがどのプロジェクトか一目で判別したいことがあります。通常、ウィンドウ名を設定するには `rename-window` コマンドを手動で実行する必要があり、プロジェクト間を移動するたびに操作が必要になります。
+
+この記事では、ディレクトリ移動時にウィンドウ名を自動的に更新する仕組みを実装する方法を紹介します。
+
+## 実装内容
+
+### tmux設定 (.tmux.conf)
+
+以下のパラメーターを `.tmux.conf` へ追加します。
+
+```conf
+## ウィンドウ名のリネーム設定（シェル側から制御）
+set-window-option -g allow-rename on
+set-window-option -g automatic-rename off
+```
+
+### zsh設定 (.zshrc)
+
+```bash
+# ==============================
+# tmux: ディレクトリ変更時にウィンドウ名を更新
+# ==============================
+if [ -n "$TMUX" ]; then
+  function tmux_rename_window() {
+    # Gitリポジトリのルートディレクトリを取得
+    local git_root=$(git rev-parse --show-toplevel 2>/dev/null)
+    if [ -n "$git_root" ]; then
+      # リポジトリ名を取得
+      local repo_name=$(basename "$git_root")
+      tmux rename-window "$repo_name"
+    else
+      # Gitリポジトリでない場合はカレントディレクトリ名
+      tmux rename-window "$(basename "$PWD")"
+    fi
+  }
+
+  # ディレクトリ変更時に自動実行
+  add-zsh-hook chpwd tmux_rename_window
+
+  # 初回起動時にも実行
+  tmux_rename_window
+fi
+```
+
+## 動作
+
+- tmux内でディレクトリを移動（`cd`コマンド）すると、ウィンドウ名が自動的に更新される
+- Gitリポジトリの場合はリポジトリ名、それ以外はカレントディレクトリ名が設定される
+
+## 実行例
+
+```bash
+cd ~/ghq/github.com/Tocyuki/dotfiles
+# → ウィンドウ名が "dotfiles" に自動変更
+
+cd ~/Documents
+# → ウィンドウ名が "Documents" に自動変更
+```
+
+## メリット
+
+- 複数のプロジェクトを開いている際に、ウィンドウ名でどのプロジェクトか一目で判別可能
+- 手動でウィンドウ名を変更する手間が不要
+- ディレクトリ移動のたびに自動更新されるため、常に最新の状態を反映
+
+## 補足
+
+### zshのchpwdフック
+
+[`chpwd`](https://zsh.sourceforge.io/Doc/Release/Functions.html)は、カレントディレクトリが変更されるたびに実行されるzshのフック関数です。[`add-zsh-hook`](https://zsh.sourceforge.io/Doc/Release/User-Contributions.html)コマンドを使用することで、複数のフック関数を登録できます。
+
+### tmuxの設定について
+
+- [`allow-rename on`](https://man7.org/linux/man-pages/man1/tmux.1.html): シェルからエスケープシーケンスを使ってウィンドウ名を変更することを許可する
+- [`automatic-rename off`](https://man7.org/linux/man-pages/man1/tmux.1.html): tmux側の自動リネーム機能を無効化し、シェル側で完全に制御できるようにする
+
+この設定により、シェルスクリプトから`tmux rename-window`コマンドでウィンドウ名を変更できるようになります。
+
+## まとめ
+
+tmuxとzshのフック機能を組み合わせることで、ディレクトリ移動時にウィンドウ名を自動的に更新できます。Gitリポジトリでの作業が多い場合、リポジトリ名が自動的にウィンドウ名に反映されるため、作業効率が向上します。
+
+この記事で紹介した設定は、筆者のdotfilesリポジトリでも公開しています。他の便利な設定も含まれているので、よろしければ参考にしてください。
+
+https://github.com/Tocyuki/dotfiles

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   npx:
     build:


### PR DESCRIPTION
## 概要

tmuxでディレクトリ移動時にウィンドウ名を自動的に更新する方法について解説した記事を追加しました。また、プロジェクトの開発環境を改善しました。

## 変更内容

### 新規記事

- **tmuxでディレクトリ移動時にウィンドウ名を自動更新する方法** (`articles/tmux-auto-rename-window-on-directory-change.md`)
  - tmuxとzshのフック機能を組み合わせた自動化手法を紹介
  - Gitリポジトリ名またはディレクトリ名に基づいて自動的にウィンドウ名を更新
  - 実装例、メリット、補足情報を含む

### プロジェクト改善

1. **CLAUDE.md の追加**
   - プロジェクト概要、開発環境、コマンド、記事執筆ガイドラインを記載
   - Claude Code利用時の参考資料として整備

2. **compose.yaml への移行**
   - `docker-compose.yml` → `compose.yaml` へリネーム
   - Docker Compose v2形式に対応（`version`フィールドを削除）
   - Makefile内のコメントも更新

3. **MCP Server設定の追加** (`.mcp.json`)
   - fetch: Web上のドキュメント取得
   - filesystem: articles/books ディレクトリへの安全なアクセス
   - git: リポジトリ管理

4. **Claude Code Hooks の設定**
   - `.claude/hooks/textlint.sh`: Markdownファイル編集時に自動でtextlintを実行
   - `.claude/settings.json`: PostToolUseフックの設定
   - 記事品質の自動チェック体制を整備

5. **README.md の改善**
   - Zennのバッジ（Likes/Articles）を追加

## 関連Issue

Closes #14

## テスト

- textlintによる記事の品質チェック: ✅ Pass
- Docker環境でのビルド確認: ✅ Pass